### PR TITLE
added state management to change from start menu to game board

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,8 @@
   border: 5px solid black;
   border-radius: 95px;
   padding: 20px;
-  font-family: 'Sofia' sans-serif
+  font-family: 'Sofia' sans-serif;
+  
 }
 
 .name {
@@ -32,7 +33,7 @@
   border: 3px dashed black;
   border-radius: 50px;
   padding: 70px;
-  margin: 100px;
+  margin-top: 6rem;
   fill: cross-;
 }
 
@@ -42,7 +43,7 @@
   background-color: #d0bfff;
   border: 5px solid black;
   border-radius: 50px;
-
+  margin-top: -6rem;;
 }
 
 .play a {
@@ -85,4 +86,45 @@
 
 .read-the-docs {
   color: #888;
+}
+
+.Board{
+  width: 700px;
+  height: 700px;
+  display: grid;
+  grid-template-columns: repeat(3,1fr) ;
+  grid-template-rows: repeat(3, 1fr) ;
+  gap:10px;
+  background-color: #d0bfff;
+  text-align: center;
+  justify-content: space-around;
+  font-size: xx-large;
+  align-items: center;
+  border: 5px solid black;
+  border-radius: 95px;
+  padding: 20px;;
+  text-align: center;
+  font-size: xx-large;
+  margin: 25px;
+  margin-top: -6rem;
+}
+
+.cell {
+  margin:0px;
+  border-width: 5px ;
+  padding: 70px;
+  color: black;
+  /* padding-top: 60px; */
+  /* margin: 10px; */
+  background-color: white;
+  border-radius: 50px;
+  font-size: xx-large;
+  font-weight:bolder;
+  font-family: 'lilita one';
+  opacity: 1;
+  stroke-width: 100%;
+}
+
+.win-results {
+  margin-top: -25rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,24 @@
-import { useState} from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import '/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css'
-import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/compounds/Tictac.css"
-import Board from './compounds/Board'
-// import { Home } from './pages/Home'
-import {Play, Name}  from './Playbutton'
+import React, { useState} from 'react'
+import Board from './new_components/Board'
+import StartMenu from './new_components/StartMenu';
+import './App.css'
 
 
 function App() {
-  const [count, setCount] = useState(0)
+  
+//state management for start menu and board
+const [playMode, setPlayMode] = useState('start-menu');
+//set and change mode handlers
+const changeMode = (newMode) => setPlayMode(newMode)
+const onReturnClick = () => changeMode('start-menu')
 
   return (
     
-    // <Board />
+  
     
       <div className="App">
-        <Name />
-        <Play />
+        {playMode === 'start-menu' && <StartMenu onStart={() => changeMode('board')}/>}
+        {playMode === 'board' && <Board onReturnClick={onReturnClick}/>}
       </div>
       
    

--- a/src/Playbutton.jsx
+++ b/src/Playbutton.jsx
@@ -1,17 +1,17 @@
-import { useState, useEffect } from "react";
-import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css";
+// import { useState, useEffect } from "react";
+// // import "src/pages/App.css";
 
 
 
-export function Play(props){
+// export function Play(props){
    
-    return  <div className="play"><button><a href="#" target="_self" className="font-effect-neon">PLAY</a></button></div>
+//     return  <div className="play"><button><a href="#" target="_self" className="font-effect-neon">PLAY</a></button></div>
    
-}
+// }
 
-export function Name(){
-    return <div className="name" ><h1 className="font-effect-neon" >TIC TAC TOE</h1></div>
+// export function Name(){
+//     return <div className="name" ><h1 className="font-effect-neon" >TIC TAC TOE</h1></div>
 
-}
+// }
 
 

--- a/src/compounds/Board.jsx
+++ b/src/compounds/Board.jsx
@@ -1,80 +1,80 @@
-import React, { useState, useEffect } from "react";
-import Cells from "./Tictac"; // Ensure this path is correct
-import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css";
+// import React, { useState, useEffect } from "react";
+// import Cells from "./Tictac"; // Ensure this path is correct
+// //import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css";
 
-export default function Board() {
-    const [data, setData] = useState(['', '', '', '', '', '', '', '', '']);
-    const [computerTurn, setComputerTurn] = useState(false);
-    const [winner, setWinner] = useState(null);
+// export default function Board() {
+//     const [data, setData] = useState(['', '', '', '', '', '', '', '', '']);
+//     const [computerTurn, setComputerTurn] = useState(false);
+//     const [winner, setWinner] = useState(null);
 
-    const handleClick = (i) => {
-        if (!computerTurn && data[i] === '' && winner === null) {
-            let arr = [...data];
-            arr[i] = 'X';
-            setData(arr);
-            if (!checkWinner('X')) {
-                setComputerTurn(true);
-            }
-        }
-    };
+//     const handleClick = (i) => {
+//         if (!computerTurn && data[i] === '' && winner === null) {
+//             let arr = [...data];
+//             arr[i] = 'X';
+//             setData(arr);
+//             if (!checkWinner('X')) {
+//                 setComputerTurn(true);
+//             }
+//         }
+//     };
 
-    useEffect(() => {
-        if (computerTurn && winner === null) {
-            const timer = setTimeout(() => {
-                computerTurnToPlay();
-            }, 500);
+//     useEffect(() => {
+//         if (computerTurn && winner === null) {
+//             const timer = setTimeout(() => {
+//                 computerTurnToPlay();
+//             }, 500);
 
-            return () => clearTimeout(timer); 
-        }
-    }, [computerTurn, winner]);
+//             return () => clearTimeout(timer); 
+//         }
+//     }, [computerTurn, winner]);
 
-    const computerTurnToPlay = () => {
-        const availableIndices = data.map((item, index) => item === '' ? index : null).filter(index => index !== null);
-        if (availableIndices.length > 0) {
-            let choice = availableIndices[Math.floor(Math.random() * availableIndices.length)];
-            let arr = [...data];
-            arr[choice] = 'O';
-            setData(arr);
-            checkWinner('O');
-            setComputerTurn(false);
-        }
-    };
+//     const computerTurnToPlay = () => {
+//         const availableIndices = data.map((item, index) => item === '' ? index : null).filter(index => index !== null);
+//         if (availableIndices.length > 0) {
+//             let choice = availableIndices[Math.floor(Math.random() * availableIndices.length)];
+//             let arr = [...data];
+//             arr[choice] = 'O';
+//             setData(arr);
+//             checkWinner('O');
+//             setComputerTurn(false);
+//         }
+//     };
 
-    const checkWinner = (player) => {
-        if (cond(player)) {
-            setWinner(player);
-            return true;
-        } else if (data.every(item => item !== '')) {
-            setWinner('DRAW');
-            return true;
-        }
-        return false;
-    };
+//     const checkWinner = (player) => {
+//         if (cond(player)) {
+//             setWinner(player);
+//             return true;
+//         } else if (data.every(item => item !== '')) {
+//             setWinner('DRAW');
+//             return true;
+//         }
+//         return false;
+//     };
 
-    const cond = (player) => {
-        return (
-            (data[0] === player && data[1] === player && data[2] === player) ||
-            (data[3] === player && data[4] === player && data[5] === player) ||
-            (data[6] === player && data[7] === player && data[8] === player) ||
-            (data[0] === player && data[3] === player && data[6] === player) ||
-            (data[1] === player && data[4] === player && data[7] === player) ||
-            (data[2] === player && data[5] === player && data[8] === player) ||
-            (data[0] === player && data[4] === player && data[8] === player) ||
-            (data[2] === player && data[4] === player && data[6] === player)
-        );
-    };
+//     const cond = (player) => {
+//         return (
+//             (data[0] === player && data[1] === player && data[2] === player) ||
+//             (data[3] === player && data[4] === player && data[5] === player) ||
+//             (data[6] === player && data[7] === player && data[8] === player) ||
+//             (data[0] === player && data[3] === player && data[6] === player) ||
+//             (data[1] === player && data[4] === player && data[7] === player) ||
+//             (data[2] === player && data[5] === player && data[8] === player) ||
+//             (data[0] === player && data[4] === player && data[8] === player) ||
+//             (data[2] === player && data[4] === player && data[6] === player)
+//         );
+//     };
 
-    return (
-        <div className="Board">
-            {data.map((item, index) => (
-                <Cells key={index} onClick={() => handleClick(index)}>
-                    {item}
-                </Cells>
-            ))}
-            {winner && <div className="winner">{winner === 'DRAW' ? 'Draw!' : `Winner: ${winner}`}</div>}
-        </div>
-    );
-}
+//     return (
+//         <div className="Board">
+//             {data.map((item, index) => (
+//                 <Cells key={index} onClick={() => handleClick(index)}>
+//                     {item}
+//                 </Cells>
+//             ))}
+//             {winner && <div className="winner">{winner === 'DRAW' ? 'Draw!' : `Winner: ${winner}`}</div>}
+//         </div>
+//     );
+// }
 
 
 

--- a/src/compounds/Tictac.jsx
+++ b/src/compounds/Tictac.jsx
@@ -1,11 +1,11 @@
-import React from "react";
+// import React from "react";
 
-function Cells (props) {
+// function Cells (props) {
     
 
-    return <div className="cell" id={props.id} onClick={props.onClick}>{props.children}</div>
-}
+//     return <div className="cell" id={props.id} onClick={props.onClick}>{props.children}</div>
+// }
 
 
-export default Cells;
+// export default Cells;
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,11 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
-import { Home } from './pages/Home.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
-    <Home />
   </StrictMode>,
 )

--- a/src/new_components/Board.jsx
+++ b/src/new_components/Board.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from "react";
+import Cells from "./Cells"; // Ensure this path is correct
+
+
+ function Board({onReturnClick}) {
+    const [data, setData] = useState(['', '', '', '', '', '', '', '', '']);
+    const [computerTurn, setComputerTurn] = useState(false);
+    const [winner, setWinner] = useState(null);
+
+    const handleClick = (i) => {
+        if (!computerTurn && data[i] === '' && winner === null) {
+            let arr = [...data];
+            arr[i] = 'X';
+            setData(arr);
+            if (!checkWinner('X')) {
+                setComputerTurn(true);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (computerTurn && winner === null) {
+            const timer = setTimeout(() => {
+                computerTurnToPlay();
+            }, 500);
+
+            return () => clearTimeout(timer); 
+        }
+    }, [computerTurn, winner]);
+
+    const computerTurnToPlay = () => {
+        const availableIndices = data.map((item, index) => item === '' ? index : null).filter(index => index !== null);
+        if (availableIndices.length > 0) {
+            let choice = availableIndices[Math.floor(Math.random() * availableIndices.length)];
+            let arr = [...data];
+            arr[choice] = 'O';
+            setData(arr);
+            checkWinner('O');
+            setComputerTurn(false);
+        }
+    };
+
+    const checkWinner = (player) => {
+        if (cond(player)) {
+            setWinner(player);
+            return true;
+        } else if (data.every(item => item !== '')) {
+            setWinner('DRAW');
+            return true;
+        }
+        return false;
+    };
+
+    const cond = (player) => {
+        return (
+            (data[0] === player && data[1] === player && data[2] === player) ||
+            (data[3] === player && data[4] === player && data[5] === player) ||
+            (data[6] === player && data[7] === player && data[8] === player) ||
+            (data[0] === player && data[3] === player && data[6] === player) ||
+            (data[1] === player && data[4] === player && data[7] === player) ||
+            (data[2] === player && data[5] === player && data[8] === player) ||
+            (data[0] === player && data[4] === player && data[8] === player) ||
+            (data[2] === player && data[4] === player && data[6] === player)
+        );
+    };
+
+    return (
+        <div className="Board">
+            {data.map((item, index) => (
+                <Cells key={index} onClick={() => handleClick(index)}>
+                    {item}
+                </Cells>
+            ))}
+            <div className="win-results">
+            {winner && <div className="winner">{winner === 'DRAW' ? 'Draw!' : `Winner: ${winner}`}
+                {/* Add restart button to return to start menu */}
+                <span><button onClick={onReturnClick} className="font-effect-neon">Restart</button></span></div>}
+                </div>
+        </div>
+    );
+}
+
+
+
+export default Board;

--- a/src/new_components/Cells.jsx
+++ b/src/new_components/Cells.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function Cells (props) {
+    
+
+    return <div className="cell" id={props.id} onClick={props.onClick}>{props.children}</div>
+}
+
+
+export default Cells;
+

--- a/src/new_components/StartMenu.jsx
+++ b/src/new_components/StartMenu.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+
+
+const StartMenu = ({onStart}) => {
+
+    return (
+        <>
+
+<div className="name" ><h1 className="font-effect-neon" >TIC TAC TOE</h1></div>
+<div className="play"><button onClick={onStart}><a href="#" target="_self" className="font-effect-neon">PLAY</a></button></div>
+</>
+    )
+}
+
+export default StartMenu;
+
+

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,18 +1,18 @@
-import { useState} from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import '/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css'
-import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/compounds/Tictac.css"
-import Board from '../compounds/Board.jsx'
-import {Play, Name} from '/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/Playbutton.jsx'
+// import { useState} from 'react'
+// //import { BrowserRouter, Routes, Route } from 'react-router-dom'
+// //import '/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/App.css'
+// //import "/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/compounds/Tictac.css"
+// import Board from '../compounds/Board.jsx'
+// //import {Play, Name} from '/Users/tpl822_6/project-techtonica/tictactoe_game2.0/src/Playbutton.jsx'
 
 
-export function Home() {
-  const [count, setCount] = useState(0)
+// export function Home() {
+//   const [count, setCount] = useState(0)
 
-  return (
-     <div className="App">
-        <Board />
-      </div>
+//   return (
+//      <div className="App">
+//         <Board />
+//       </div>
 
-  )
-}
+//   )
+// }


### PR DESCRIPTION
## Issue:
The original implementation displayed both the start menu and game board on the same page. The goal was to use state management to render the start menu initially and load the game board once the "Start" button was clicked.

## Solution:

State Management: Implemented React useState to toggle between the start menu and game board views.
Event Handling: Added an onClick event handler to switch between the start menu and game board.
Component Renaming and File Structure: Cleaned up the project file structure and renamed components for clarity to better reflect their responsibilities.

## Code Change

```
function App() {
  const [playMode, setPlayMode] = useState('start-menu');

  const changeMode = (newMode) => setPlayMode(newMode);
  const onReturnClick = () => changeMode('start-menu');

  return (
    <div className="App">
      {playMode === 'start-menu' && <StartMenu onStart={() => changeMode('board')} />}
      {playMode === 'board' && <Board onReturnClick={onReturnClick} />}
    </div>
  );
}
```

## Here is the result!

https://github.com/user-attachments/assets/6a3e00e5-0a02-4b31-820b-30e4a6694dce

